### PR TITLE
Experimental: Bundled updates

### DIFF
--- a/pkg/collect/collect.go
+++ b/pkg/collect/collect.go
@@ -94,6 +94,7 @@ func (c Events2Poll) Collect(events chan<- resource.Event, errors chan<- error) 
 		for res := range remainingResources {
 			events <- resource.NewUnconfiguredRes(res)
 		}
+		events <- resource.NewDisplayEvent()
 		<-ticker.C
 	}
 }

--- a/pkg/display/fancy_tui.go
+++ b/pkg/display/fancy_tui.go
@@ -123,8 +123,11 @@ func (f *FancyTUI) UpdateResources(event <-chan resource.Event, err <-chan error
 				// THINK: channel or something...
 				// done = true
 			}
+			if evt.Target == resource.DisplayEvent {
+				f.resources.UpdateList()
+				f.updateDisp <- struct{}{}
+			}
 			f.resources.Update(evt)
-			f.updateDisp <- struct{}{}
 		case err := <-err:
 			if len(f.lastErr) >= 5 {
 				f.lastErr = append(f.lastErr[1:], err)

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -30,6 +30,9 @@ import (
 // EOF is the End Of File sentinel to signal no further Events are expected.
 const EOF = "EOF"
 
+// DisplayEvent is the sentinel to signal a display update
+const DisplayEvent = "DisplayEvent"
+
 type resKeys struct {
 	Name          string
 	Role          string
@@ -325,6 +328,11 @@ func NewEvent(e string) (Event, error) {
 // NewEOF returns a special Event signaling that no further input should be expected.
 func NewEOF() Event {
 	return Event{Target: EOF}
+}
+
+// NewDisplayEvent returns a special Event signaling that the display should be updated
+func NewDisplayEvent() Event {
+	return Event{Target: DisplayEvent}
 }
 
 // NewUnconfiguredRes returns a special Event signaling that this resource is down(unconfigured).

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -164,6 +164,11 @@ func (rc *ResourceCollection) Update(e resource.Event) {
 		}
 		rc.Map[resName].Update(e)
 	}
+}
+
+func (rc *ResourceCollection) UpdateList() {
+	rc.Lock()
+	defer rc.Unlock()
 
 	// Rebuild list from map values.
 	rc.List = []*ByRes{}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -91,6 +91,7 @@ func TestResourceCollection(t *testing.T) {
 
 	rc := NewResourceCollection(0) // Turn off pruning with zero.
 	rc.Update(evt)
+	rc.UpdateList()
 
 	if _, ok := rc.Map["test10"]; !ok {
 		t.Error("TestResourceCollection: Expected test10 to exist")
@@ -102,6 +103,7 @@ func TestResourceCollection(t *testing.T) {
 		t.Fatal(err)
 	}
 	rc.Update(evt)
+	rc.UpdateList()
 
 	if rc.List[1].Res.Name != "test100" {
 		t.Errorf("TestResourceCollection: Expected test100 to be sorted last. Got %s", rc.List[1].Res.Name)


### PR DESCRIPTION
Perform all the updates that were received in one drbdsetup call, then rebuild and order the list used for displaying and update the display.

I am not sure about the guarantees regarding the consistency of the resource collection map and the associated list, and about locking, so please check carefully, because while it worked in my tests now, it might unintentionally break future functionality.

The change works by introducing a new event type that is used as a signal for display updates in combination with a new ResourceCollection method UpdateList() that contains list rebuilding and ordering logic removed from Update(). The ResourceCollection lock is held while working on the list. 

The lock is no longer held between updates of the map and the list, so the main question to think about would be whether or not map changes are allowed to be visible before the list is changed accordingly as well.