### PR TITLE
Added support for the new DRBD quorum feature

### DIFF
--- a/pkg/display/fancy_overview.go
+++ b/pkg/display/fancy_overview.go
@@ -154,10 +154,8 @@ func (o *overView) UpdateTable() {
 
 				ucfg := res.Unconfigured
 
-				var quorumLabel string
-				if ucfg {
-					quorumLabel = "-"
-				} else {
+				quorumLabel := "-"
+				if !ucfg {
 					quorumAlert := false
 					for _, vol := range r.Device.Volumes {
 						if vol.QuorumAlert {

--- a/pkg/display/fancy_overview.go
+++ b/pkg/display/fancy_overview.go
@@ -131,7 +131,7 @@ func (o *overView) UpdateTable() {
 		o.from, o.to = from, to
 		if len(db.keys[from:to]) > 0 {
 			tblrows := make([][]string, len(db.keys[from:to])+1)
-			tblrows[0] = []string{"Name", "Role", "Disks", "Peer Disks", "Connections", "Overall"}
+			tblrows[0] = []string{"Name", "Role", "Disks", "Peer Disks", "Connections", "Overall", "Quorum"}
 			for idx, rname := range db.keys[from:to] {
 				r := db.buf[rname]
 				res := db.buf[rname].Res
@@ -154,11 +154,30 @@ func (o *overView) UpdateTable() {
 
 				ucfg := res.Unconfigured
 
+				var quorumLabel string
+				if ucfg {
+					quorumLabel = "-"
+				} else {
+					quorumAlert := false
+					for _, vol := range r.Device.Volumes {
+						if vol.QuorumAlert {
+							quorumAlert = true
+							break
+						}
+					}
+					if quorumAlert {
+						quorumLabel = colRed("✗", false)
+					} else {
+						quorumLabel = colGreen("✓", false)
+					}
+				}
+
 				tblrows[idx+1] = []string{res.Name, role,
 					dangerToString(devdanger, ucfg),
 					dangerToString(pddanger, ucfg),
 					dangerToString(conndanger, ucfg),
-					dangerToString(r.Danger, false)}
+					dangerToString(r.Danger, false),
+					quorumLabel}
 			}
 			o.tbl.SetRows(tblrows)
 			for i := 1; i < len(o.tbl.Rows); i++ { // skip header


### PR DESCRIPTION
There is now an additional per-resource "Quorum" column in the overview display. Per-resource reporting is a simple green checkmark or red cross, indicating quorum being present or lost, or a gray dash if the resource is unconfigured.
Quorum is reported present unless DRBD reports quorum lost (thereby making it backwards compatible with DRBD versions that do not support quorum or resources where quorum is not configured; both will always report having quorum). Lost quorum adds a danger score of 30 per volume where the quorum is lost. The entire resource loses quorum if at least one of its volumes loses quorum.