### PR TITLE
Proposed partial fix for issue #13 (a race condition with long poll cycle)

### DIFF
--- a/pkg/display/fancy_tui.go
+++ b/pkg/display/fancy_tui.go
@@ -126,8 +126,11 @@ func (f *FancyTUI) UpdateResources(event <-chan resource.Event, err <-chan error
 			if evt.Target == resource.DisplayEvent {
 				f.resources.UpdateList()
 				f.updateDisp <- struct{}{}
+			} else if evt.Target == resource.PruneEvent {
+				f.resources.Prune(evt)
+			} else {
+				f.resources.Update(evt)
 			}
-			f.resources.Update(evt)
 		case err := <-err:
 			if len(f.lastErr) >= 5 {
 				f.lastErr = append(f.lastErr[1:], err)

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -33,6 +33,9 @@ const EOF = "EOF"
 // DisplayEvent is the sentinel to signal a display update
 const DisplayEvent = "DisplayEvent"
 
+// PruneEvent is the sentinel to signal a prune operation
+const PruneEvent = "PruneEvent"
+
 type resKeys struct {
 	Name          string
 	Role          string
@@ -344,6 +347,11 @@ func NewEOF() Event {
 // NewDisplayEvent returns a special Event signaling that the display should be updated
 func NewDisplayEvent() Event {
 	return Event{Target: DisplayEvent}
+}
+
+// NewPruneEvent returns a special Event signaling that the display should prune outdated data
+func NewPruneEvent() Event {
+	return Event{Target: PruneEvent}
 }
 
 // NewUnconfiguredRes returns a special Event signaling that this resource is down(unconfigured).

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -147,15 +147,20 @@ func NewResourceCollection(d time.Duration) *ResourceCollection {
 	}
 }
 
-// Update a collection of ByRes from an Event.
-func (rc *ResourceCollection) Update(e resource.Event) {
+func (rc *ResourceCollection) Prune(e resource.Event) {
 	rc.Lock()
 	defer rc.Unlock()
 
 	// Clean up old data.
 	if rc.updateInterval != 0 {
-		rc.prune(e.TimeStamp.Add(-3 * rc.updateInterval))
+		rc.pruneImpl(e.TimeStamp.Add(-3 * rc.updateInterval))
 	}
+}
+
+// Update a collection of ByRes from an Event.
+func (rc *ResourceCollection) Update(e resource.Event) {
+	rc.Lock()
+	defer rc.Unlock()
 
 	resName := e.Fields[resource.ResKeys.Name]
 	if resName != "" {
@@ -180,7 +185,7 @@ func (rc *ResourceCollection) UpdateList() {
 }
 
 // Remove old fields that haven't been updated since time.
-func (rc *ResourceCollection) prune(t time.Time) {
+func (rc *ResourceCollection) pruneImpl(t time.Time) {
 	for k, v := range rc.Map {
 		if v.Res.CurrentTime.Before(t) {
 			delete(rc.Map, k)


### PR DESCRIPTION
The proposed fix prunes entries once after each poll cycle, based on the timestamp of the earliest event generated by that poll cycle, or a drbdtop-internal timestamp if no events were received from drbdsetup.
(Some more details in the commit message)

It's not a 100% fix, because pruning was apparently supposed to happen if the last ~3 poll cycles did not update the resource, and if poll cycles take longer than the poll interval, then it might still remove entries that were updated within the last 3 poll cycles, but it will not remove entries that were updated in the current poll cycle, so all currently active/configured resources will be displayed, even if the poll cycle takes much longer than the configured poll interval.