### PR TITLE
Small optimization and code restructuring

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -159,10 +159,12 @@ func (rc *ResourceCollection) Update(e resource.Event) {
 
 	resName := e.Fields[resource.ResKeys.Name]
 	if resName != "" {
-		if _, ok := rc.Map[resName]; !ok {
-			rc.Map[resName] = NewByRes()
+		resource, ok := rc.Map[resName]
+		if !ok {
+			resource = NewByRes()
+			rc.Map[resName] = resource
 		}
-		rc.Map[resName].Update(e)
+		resource.Update(e)
 	}
 }
 


### PR DESCRIPTION
Commit `8c67b0876e2381af3c91647877e0e0b3180c0b96` avoids a duplicate map lookup. Should probably be applied.

Commit `3f6ebd6ad799602849ecd8cc85b3830c8e0e5faa` restructures code, avoiding some code duplication for a special case. Low importance, this may be a somewhat cleaner solution than the existing one.