### PR TITLE
Avoid duplicate map lookup (in update.go)

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -159,10 +159,12 @@ func (rc *ResourceCollection) Update(e resource.Event) {
 
 	resName := e.Fields[resource.ResKeys.Name]
 	if resName != "" {
-		if _, ok := rc.Map[resName]; !ok {
-			rc.Map[resName] = NewByRes()
+		resource, ok := rc.Map[resName]
+		if !ok {
+			resource = NewByRes()
+			rc.Map[resName] = resource
 		}
-		rc.Map[resName].Update(e)
+		resource.Update(e)
 	}
 }
 


### PR DESCRIPTION
Just a simple optimization in case a ByRes is not in the map already